### PR TITLE
Fix a comment for TOG being for SIGGRAPH

### DIFF
--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -493,7 +493,7 @@ ISMB_Bioinformatics = {
     2007: (23, 13),
 }
 
-# TOG special handling to count only EUROGRAPHICS proceedings.
+# TOG special handling to count only SIGGRAPH proceedings.
 # Assuming all will be in the same issues through 2023.
 TOG_SIGGRAPH_Volume = {
     2023: (42, 4),


### PR DESCRIPTION
Just a minor typo mentioning a wrong conference in the comment. Fix it to match the code.